### PR TITLE
chore: update version of actions/upload-artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: dist
           name: dist
@@ -44,7 +44,7 @@ jobs:
           mkdir pull_request
           echo ${{ github.event.pull_request.number }} > ./pull_request/number
       - name: Upload pull request data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: .
           name: pull-request-data


### PR DESCRIPTION
This commit updates the reference to the `action/upload-artifact` Git Hub action from `v3` to `ea165f8d65b6e75b540449e92b4886f43607fa02` which is version 4.6.2